### PR TITLE
V0.0.5

### DIFF
--- a/src/Entitas-Flux/Readme/Jenny.properties
+++ b/src/Entitas-Flux/Readme/Jenny.properties
@@ -28,7 +28,8 @@ Jenny.CodeGenerators = Entitas.CodeGeneration.Plugins.ComponentContextApiGenerat
                        Entitas.VisualDebugging.CodeGeneration.Plugins.ContextObserverGenerator, \
                        Entitas.VisualDebugging.CodeGeneration.Plugins.FeatureClassGenerator, \
                        Entitas.Roslyn.CodeGeneration.Plugins.CleanupSystemGenerator, \
-                       Entitas.Roslyn.CodeGeneration.Plugins.CleanupSystemsGenerator
+                       Entitas.Roslyn.CodeGeneration.Plugins.CleanupSystemsGenerator, \
+                       Entitas.Roslyn.CodeGeneration.Plugins.Watched.CodeGenerators.WatchedEntityHasChangedGenerator
 Jenny.PostProcessors = Jenny.Plugins.AddFileHeaderPostProcessor, \
                        Jenny.Plugins.CleanTargetDirectoryPostProcessor, \
                        Jenny.Plugins.MergeFilesPostProcessor, \

--- a/src/Entitas-Flux/Tests/TestFixtures/Fixtures/Components/DontGenerateEntityIndexComponent.cs
+++ b/src/Entitas-Flux/Tests/TestFixtures/Fixtures/Components/DontGenerateEntityIndexComponent.cs
@@ -1,0 +1,9 @@
+using Entitas;
+using Entitas.CodeGeneration.Attributes;
+
+[Context("Test"), DontGenerate]
+public sealed class DontGenerateEntityIndexComponent : IComponent
+{
+	[EntityIndex]
+	public string value;
+}

--- a/src/Entitas-Flux/Tests/TestFixtures/Jenny.properties
+++ b/src/Entitas-Flux/Tests/TestFixtures/Jenny.properties
@@ -28,7 +28,8 @@ Jenny.CodeGenerators = Entitas.CodeGeneration.Plugins.ComponentContextApiGenerat
                        Entitas.VisualDebugging.CodeGeneration.Plugins.ContextObserverGenerator, \
                        Entitas.VisualDebugging.CodeGeneration.Plugins.FeatureClassGenerator, \
                        Entitas.Roslyn.CodeGeneration.Plugins.CleanupSystemGenerator, \
-                       Entitas.Roslyn.CodeGeneration.Plugins.CleanupSystemsGenerator
+                       Entitas.Roslyn.CodeGeneration.Plugins.CleanupSystemsGenerator, \
+                       Entitas.Roslyn.CodeGeneration.Plugins.Watched.CodeGenerators.WatchedEntityHasChangedGenerator
 Jenny.PostProcessors = Jenny.Plugins.AddFileHeaderPostProcessor, \
                        Jenny.Plugins.CleanTargetDirectoryPostProcessor, \
                        Jenny.Plugins.MergeFilesPostProcessor, \

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/CodeGenerators/WatchedComponentGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/CodeGenerators/WatchedComponentGenerator.cs
@@ -26,6 +26,7 @@ public class ${ComponentName}Changed : Entitas.IComponent { }
 			string[] allContexts = group
 				.SelectMany(d => d.GetContextNames())
 				.Distinct()
+				.OrderBy(ctx => ctx)
 				.ToArray();
 			string contexts = string.Join(", ", allContexts);
 

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/CodeGenerators/WatchedComponentGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/CodeGenerators/WatchedComponentGenerator.cs
@@ -16,19 +16,24 @@ public class ${ComponentName}Changed : Entitas.IComponent { }
 		public override CodeGenFile[] Generate(CodeGeneratorData[] data) => data
 			.OfType<ComponentData>()
 			.Where(d => d.ShouldWatchChanges())
-			.Select(GenerateSingle)
+			.GroupBy(d => d.ComponentName())
+			.Select(GenerateForGroup)
 			.ToArray();
 
-		CodeGenFile GenerateSingle(ComponentData data)
+		CodeGenFile GenerateForGroup(IGrouping<string, ComponentData> group)
 		{
-			string[] names = data.GetContextNames();
-			string contexts = string.Join(", ", names);
+			string componentName = group.Key;
+			string[] allContexts = group
+				.SelectMany(d => d.GetContextNames())
+				.Distinct()
+				.ToArray();
+			string contexts = string.Join(", ", allContexts);
 
 			string fileContent = TEMPLATE
-				.Replace("${ComponentName}", data.ComponentName())
+				.Replace("${ComponentName}", componentName)
 				.Replace("${Contexts}", contexts);
 
-			string fileName = (data.ComponentName() + "Changed").AddComponentSuffix();
+			string fileName = (componentName + "Changed").AddComponentSuffix();
 			string path = "Components" + Path.DirectorySeparatorChar + fileName + ".cs";
 
 			return new CodeGenFile(path, fileContent, GetType().FullName);

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProvider.cs
@@ -111,6 +111,13 @@ namespace Entitas.CodeGeneration.Plugins
             var dataFromWatched = mergedData
                 .Where(data => data.ShouldWatchChanges())
                 .SelectMany(data => createDataForWatched(data))
+                .GroupBy(d => d.GetTypeName())
+                .Select(g =>
+                {
+                    var first = g.First();
+                    first.SetContextNames(g.SelectMany(d => d.GetContextNames()).Distinct().ToArray());
+                    return first;
+                })
                 .ToArray();
 
             return merge(dataFromWatched, mergedData);

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProviders/ShouldGenerateComponentIndexComponentDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProviders/ShouldGenerateComponentIndexComponentDataProvider.cs
@@ -18,7 +18,7 @@ namespace Entitas.CodeGeneration.Plugins
                 .OfType<DontGenerateAttribute>()
                 .SingleOrDefault();
 
-            return attr == null || attr.generateIndex;
+            return attr == null;
         }
     }
 

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/EntityIndex/CodeGenerators/EntityIndexGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/EntityIndex/CodeGenerators/EntityIndexGenerator.cs
@@ -83,7 +83,8 @@ ${getIndices}
                 .Select(d => INDEX_CONSTANTS_TEMPLATE
                     .Replace("${IndexName}", d.GetHasMultiple()
                         ? d.GetEntityIndexName() + d.GetMemberName().ToUpperFirst()
-                        : d.GetEntityIndexName())));
+                        : d.GetEntityIndexName()))
+                .Distinct());
 
             var addIndices = string.Join("\n\n", data
                 .Select(generateAddMethods));

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/EntityIndex/DataProviders/EntityIndexDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration.Plugins/src/EntityIndex/DataProviders/EntityIndexDataProvider.cs
@@ -57,6 +57,7 @@ namespace Entitas.CodeGeneration.Plugins
             var entityIndexData = types
                 .Where(type => !type.IsAbstract)
                 .Where(type => type.ImplementsInterface<IComponent>())
+                .Where(type => !Attribute.IsDefined(type, typeof(DontGenerateAttribute)))
                 .ToDictionary(
                     type => type,
                     type => type.GetPublicMemberInfos())

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration/tests/EntityIndexDataProviderTests.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration/tests/EntityIndexDataProviderTests.cs
@@ -147,6 +147,12 @@ namespace Entitas.CodeGeneration.Tests
             d.GetContextNames()[0].Should().Be("ConfiguredContext");
         }
 
+        [Fact]
+        public void IgnoresComponentsMarkedDontGenerate()
+        {
+            GetData<DontGenerateEntityIndexComponent, StandardComponent>().Should().HaveCount(0);
+        }
+
         EntityIndexData[] GetData<T1, T2>(Preferences preferences = null)
         {
             var provider = new EntityIndexDataProvider(new[] {typeof(T1), typeof(T2)});

--- a/src/Entitas-Flux/src/Entitas.CodeGeneration/tests/RoslynEntityIndexDataProviderTests.cs
+++ b/src/Entitas-Flux/src/Entitas.CodeGeneration/tests/RoslynEntityIndexDataProviderTests.cs
@@ -129,6 +129,12 @@ namespace Entitas.CodeGeneration.Tests
             d.GetContextNames()[0].Should().Be("ConfiguredContext");
         }
 
+        [Fact]
+        public void IgnoresComponentsMarkedDontGenerate()
+        {
+            GetData<DontGenerateEntityIndexComponent, StandardComponent>().Length.Should().Be(0);
+        }
+
         INamedTypeSymbol GetSymbol<T>() => Types.Single(c => c.ToCompilableString() == typeof(T).FullName);
 
         EntityIndexData[] GetData<T1, T2>(Preferences preferences = null)

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Cleanup/CodeGenerators/CleanupSystemsGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Cleanup/CodeGenerators/CleanupSystemsGenerator.cs
@@ -45,12 +45,14 @@ ${systemsList}
         }
 
         CodeGenFile[] generate(Dictionary<string, List<CleanupData>> contextNameToCleanupData) => contextNameToCleanupData
+            .OrderBy(kv => kv.Key)
             .Select(kv => generate(kv.Key, kv.Value.ToArray()))
             .ToArray();
 
         CodeGenFile generate(string contextName, CleanupData[] data)
         {
             var systemsList = string.Join("\n", data
+                .OrderBy(d => d.componentData.ComponentName())
                 .Select(d => "        Add(new " +
                              (d.cleanupMode == CleanupMode.DestroyEntity ? "Destroy" : "Remove") +
                              d.componentData.ComponentName() + contextName.AddSystemSuffix() + "(contexts));"));

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProvider.cs
@@ -117,7 +117,7 @@ namespace Entitas.Roslyn.CodeGeneration.Plugins
                 .Select(g =>
                 {
                     var first = g.First();
-                    first.SetContextNames(g.SelectMany(d => d.GetContextNames()).Distinct().ToArray());
+                    first.SetContextNames(g.SelectMany(d => d.GetContextNames()).Distinct().OrderBy(ctx => ctx).ToArray());
                     return first;
                 })
                 .ToArray();

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProvider.cs
@@ -113,6 +113,13 @@ namespace Entitas.Roslyn.CodeGeneration.Plugins
             var dataFromTrackingChanges = mergedData
                 .Where(data => data.ShouldWatchChanges())
                 .SelectMany(data => createDataForWatched(data))
+                .GroupBy(d => d.GetTypeName())
+                .Select(g =>
+                {
+                    var first = g.First();
+                    first.SetContextNames(g.SelectMany(d => d.GetContextNames()).Distinct().ToArray());
+                    return first;
+                })
                 .ToArray();
 
             return merge(dataFromTrackingChanges, mergedData);

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProviders/ShouldGenerateComponentIndexComponentDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProviders/ShouldGenerateComponentIndexComponentDataProvider.cs
@@ -16,7 +16,7 @@ namespace Entitas.Roslyn.CodeGeneration.Plugins
         bool getGenerateIndex(INamedTypeSymbol type)
         {
             var attr = type.GetAttribute<DontGenerateAttribute>();
-            return attr == null || (bool)(attr.ConstructorArguments.First().Value);
+            return attr == null;
         }
     }
 }

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProviders/ShouldGenerateComponentIndexComponentDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Component/DataProviders/ComponentDataProviders/ShouldGenerateComponentIndexComponentDataProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using DesperateDevs.Roslyn;
+﻿using DesperateDevs.Roslyn;
 using Entitas.CodeGeneration.Attributes;
 using Entitas.CodeGeneration.Plugins;
 using Microsoft.CodeAnalysis;

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/EntityIndex/DataProviders/EntityIndexDataProvider.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/EntityIndex/DataProviders/EntityIndexDataProvider.cs
@@ -58,6 +58,7 @@ namespace Entitas.Roslyn.CodeGeneration.Plugins
             var entityIndexData = types
                 .Where(type => type.AllInterfaces.Any(i => i.ToCompilableString() == componentInterface))
                 .Where(type => !type.IsAbstract)
+                .Where(type => type.GetAttribute<DontGenerateAttribute>() == null)
                 .ToDictionary(
                     type => type,
                     type => type.GetPublicMembers(true))

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Watched/CodeGenerators/WatchedCleanupSystemsGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Watched/CodeGenerators/WatchedCleanupSystemsGenerator.cs
@@ -38,12 +38,13 @@ ${systemsList}
 					return dict;
 				});
 
-			return byContext.Select(kv => Generate(kv.Key, kv.Value.ToArray())).ToArray();
+			return byContext.OrderBy(kv => kv.Key).Select(kv => Generate(kv.Key, kv.Value.ToArray())).ToArray();
 		}
 
 		CodeGenFile Generate(string contextName, WatchedCleanupData[] data)
 		{
 			var systemsList = string.Join("\n", data
+				.OrderBy(d => d.componentData.ComponentName())
 				.Select(d => $"        Add(new Remove{d.componentData.ComponentName()}Changed{contextName.AddSystemSuffix()}(contexts));"));
 
 			var fileContent = TEMPLATE

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Watched/CodeGenerators/WatchedEntityHasChangedGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Watched/CodeGenerators/WatchedEntityHasChangedGenerator.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using System.Linq;
+using Jenny;
+using Entitas.CodeGeneration.Plugins;
+
+namespace Entitas.Roslyn.CodeGeneration.Plugins.Watched.CodeGenerators
+{
+    public sealed class WatchedEntityHasChangedGenerator : AbstractGenerator
+    {
+        public override string Name => "Entity (HasChanged for Watched Components)";
+
+        const string Template =
+@"public sealed partial class ${EntityType} {
+
+    /// <summary>
+    /// Indicates whether the component with the given ID has changed since the last network tick.
+    /// </summary>
+    public bool HasChanged(int lookupComponentId) => lookupComponentId switch {
+${hasChangedCases}
+        _ => false
+    };
+
+    /// <summary>
+    /// Indicates whether the given component ID corresponds to a ""changed"" flag component, like `CurrentHealthChanged`.
+    /// </summary>
+    public bool ComponentIsChangedFlag(int lookupComponentId) => lookupComponentId switch {
+${isChangedFlagCases}
+        _ => false
+    };
+
+    /// <summary>
+    /// Given a ""changed"" flag component ID, returns the original component ID it corresponds to.
+    /// </summary>
+    public int GetOriginalComponentIdFromChangeFlag(int lookupComponentId) => lookupComponentId switch {
+${originalIdFromFlagCases}
+        _ => throw new System.ArgumentException($""Component ID {lookupComponentId} is not a recognized 'changed' flag component."")
+    };
+
+    /// <summary>
+    /// Indicates whether the component with the given ID is a watched component.
+    /// </summary>
+    public bool IsWatchedComponent(int lookupComponentId) => lookupComponentId switch {
+${isWatchedComponentCases}
+        _ => false
+    };
+}
+";
+
+        public override CodeGenFile[] Generate(CodeGeneratorData[] data)
+        {
+            var watched = data
+                .OfType<ComponentData>()
+                .Where(d => d.ShouldWatchChanges())
+                .ToArray();
+
+            if (watched.Length == 0)
+                return new CodeGenFile[0];
+
+            var byContext = watched
+                .SelectMany(d => d.GetContextNames().Select(ctx => new { ctx, d }))
+                .GroupBy(x => x.ctx, x => x.d);
+
+            return byContext
+                .Select(g => Generate(g.Key, g.ToArray()))
+                .ToArray();
+        }
+
+        CodeGenFile Generate(string contextName, ComponentData[] watched)
+        {
+            var lookupType = contextName + CodeGeneratorExtensions.LOOKUP;
+
+            watched = watched.OrderBy(d => d.ComponentName()).ToArray();
+
+            var hasChangedCases = string.Join("\n", watched
+                .Select(d =>
+                    $"        {lookupType}.{d.ComponentName()} => is{d.ComponentName()}Changed,"));
+
+            var isChangedFlagCases = string.Join("\n", watched
+                .Select(d =>
+                    $"        {lookupType}.{d.ComponentName()}Changed => true,"));
+
+            var originalIdFromFlagCases = string.Join("\n", watched
+                .Select(d =>
+                    $"        {lookupType}.{d.ComponentName()}Changed => {lookupType}.{d.ComponentName()},"));
+
+            var isWatchedComponentCases = string.Join("\n", watched
+                .Select(d =>
+                    $"        {lookupType}.{d.ComponentName()} => true,"));
+
+            var fileContent = Template
+                .Replace("${EntityType}", contextName.AddEntitySuffix())
+                .Replace("${hasChangedCases}", hasChangedCases)
+                .Replace("${isChangedFlagCases}", isChangedFlagCases)
+                .Replace("${originalIdFromFlagCases}", originalIdFromFlagCases)
+                .Replace("${isWatchedComponentCases}", isWatchedComponentCases);
+
+            var fileName = $"{contextName.AddEntitySuffix()}.HasChanged.cs";
+
+            return new CodeGenFile(
+                contextName + Path.DirectorySeparatorChar +
+                "Entities" + Path.DirectorySeparatorChar +
+                fileName,
+                fileContent,
+                GetType().FullName
+            );
+        }
+    }
+}

--- a/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Watched/CodeGenerators/WatchedEntityHasChangedGenerator.cs
+++ b/src/Entitas-Flux/src/Entitas.Roslyn.CodeGeneration.Plugins/src/Watched/CodeGenerators/WatchedEntityHasChangedGenerator.cs
@@ -43,6 +43,22 @@ ${originalIdFromFlagCases}
 ${isWatchedComponentCases}
         _ => false
     };
+
+    /// <summary>
+    /// Given a component ID, returns the corresponding ""changed"" flag component ID.
+    /// </summary>
+    public int GetChangedFlagIdOf(int lookupComponentId) => lookupComponentId switch {
+${changedFlagIdOfCases}
+        _ => throw new System.ArgumentException($""Component ID {lookupComponentId} does not have a corresponding 'changed' flag component."")
+    };
+
+    /// <summary>
+    /// Given a component ID, returns the corresponding ""changed"" flag component Type.
+    /// </summary>
+    public System.Type GetChangeFlagTypeOf(int changeComponentTypeId) => changeComponentTypeId switch {
+${changeFlagTypeOfCases}
+        _ => throw new System.ArgumentException($""Component ID {changeComponentTypeId} does not have a corresponding 'changed' flag component type."")
+    };
 }
 ";
 
@@ -87,12 +103,22 @@ ${isWatchedComponentCases}
                 .Select(d =>
                     $"        {lookupType}.{d.ComponentName()} => true,"));
 
+            var changedFlagIdOfCases = string.Join("\n", watched
+                .Select(d =>
+                    $"        {lookupType}.{d.ComponentName()} => {lookupType}.{d.ComponentName()}Changed,"));
+
+            var changeFlagTypeOfCases = string.Join("\n", watched
+                .Select(d =>
+                    $"        {lookupType}.{d.ComponentName()} => typeof(global::{d.ComponentName()}Changed),"));
+
             var fileContent = Template
                 .Replace("${EntityType}", contextName.AddEntitySuffix())
                 .Replace("${hasChangedCases}", hasChangedCases)
                 .Replace("${isChangedFlagCases}", isChangedFlagCases)
                 .Replace("${originalIdFromFlagCases}", originalIdFromFlagCases)
-                .Replace("${isWatchedComponentCases}", isWatchedComponentCases);
+                .Replace("${isWatchedComponentCases}", isWatchedComponentCases)
+                .Replace("${changedFlagIdOfCases}", changedFlagIdOfCases)
+                .Replace("${changeFlagTypeOfCases}", changeFlagTypeOfCases);
 
             var fileName = $"{contextName.AddEntitySuffix()}.HasChanged.cs";
 

--- a/src/Entitas-Flux/src/Entitas.VisualDebugging.Unity.Editor/src/Entity/Entity/EntityDrawer.cs
+++ b/src/Entitas-Flux/src/Entitas.VisualDebugging.Unity.Editor/src/Entity/Entity/EntityDrawer.cs
@@ -5,6 +5,7 @@ using DesperateDevs.Extensions;
 using DesperateDevs.Reflection;
 using DesperateDevs.Serialization;
 using DesperateDevs.Unity.Editor;
+using Entitas.CodeGeneration.Attributes;
 using UnityEditor;
 using UnityEngine;
 
@@ -131,6 +132,30 @@ namespace Entitas.VisualDebugging.Unity.Editor
             var componentType = entity.contextInfo.componentTypes[index];
             var component = entity.CreateComponent(index, componentType);
             entity.AddComponent(index, component);
+            MarkWatchedComponentChanged(entity, index);
+        }
+
+        private static void MarkWatchedComponentChanged(IEntity entity, int index)
+        {
+            var componentType = entity.contextInfo.componentTypes[index];
+            if (!Attribute.IsDefined(componentType, typeof(WatchedAttribute)))
+                return;
+
+            var componentName = entity.contextInfo.componentNames[index];
+            var changedName = componentName + "Changed";
+            var componentNames = entity.contextInfo.componentNames;
+            for (int i = 0; i < componentNames.Length; i++)
+            {
+                if (componentNames[i] == changedName)
+                {
+                    if (!entity.HasComponent(i))
+                    {
+                        var changedComponent = entity.CreateComponent(i, entity.contextInfo.componentTypes[i]);
+                        entity.AddComponent(i, changedComponent);
+                    }
+                    return;
+                }
+            }
         }
 
         public static void DrawComponent(bool[] unfoldedComponents, string[] componentMemberSearch, IEntity entity, int index, IComponent component)
@@ -163,7 +188,10 @@ namespace Entitas.VisualDebugging.Unity.Editor
                             }
 
                             if (EditorLayout.MiniButton("-"))
+                            {
                                 entity.RemoveComponent(index);
+                                MarkWatchedComponentChanged(entity, index);
+                            }
                         }
                         EditorGUILayout.EndHorizontal();
 
@@ -197,7 +225,10 @@ namespace Entitas.VisualDebugging.Unity.Editor
                             }
 
                             if (changed)
+                            {
                                 entity.ReplaceComponent(index, newComponent);
+                                MarkWatchedComponentChanged(entity, index);
+                            }
                             else
                                 entity.GetComponentPool(index).Push(newComponent);
                         }

--- a/src/Entitas-Flux/src/Entitas/src/Context/Context.cs
+++ b/src/Entitas-Flux/src/Entitas/src/Context/Context.cs
@@ -235,6 +235,20 @@ namespace Entitas
             return entityIndex;
         }
 
+        /// Determines whether the context has an IEntityIndex with the specified name.
+        public bool HasEntityIndex(string name) => _entityIndices.ContainsKey(name);
+
+        /// Removes the IEntityIndex for the specified name.
+        /// The entity index will be deactivated before removal.
+        public void RemoveEntityIndex(string name)
+        {
+            if (!_entityIndices.TryGetValue(name, out var entityIndex))
+                throw new ContextEntityIndexDoesNotExistException(this, name);
+
+            entityIndex.Deactivate();
+            _entityIndices.Remove(name);
+        }
+
         /// Resets the creationIndex back to 0.
         public void ResetCreationIndex() => _creationIndex = 0;
 

--- a/src/Entitas-Flux/src/Entitas/src/Context/IContext.cs
+++ b/src/Entitas-Flux/src/Entitas/src/Context/IContext.cs
@@ -26,6 +26,8 @@ namespace Entitas
 
         void AddEntityIndex(IEntityIndex entityIndex);
         IEntityIndex GetEntityIndex(string name);
+        bool HasEntityIndex(string name);
+        void RemoveEntityIndex(string name);
 
         void ResetCreationIndex();
         void ClearComponentPool(int index);

--- a/src/Entitas-Flux/src/Entitas/tests/ContextTests.cs
+++ b/src/Entitas-Flux/src/Entitas/tests/ContextTests.cs
@@ -701,6 +701,78 @@ namespace Entitas.Tests
         }
 
         [Fact]
+        public void DoesNotHaveEntityIndexWhenNoneAdded()
+        {
+            _context.HasEntityIndex("unknown").Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasEntityIndexAfterAdding()
+        {
+            var entityIndex = new PrimaryEntityIndex<TestEntity, string>(
+                "TestIndex",
+                _context.GetGroup(Matcher<TestEntity>.AllOf(1)),
+                (_, _) => string.Empty
+            );
+            _context.AddEntityIndex(entityIndex);
+            _context.HasEntityIndex(entityIndex.name).Should().BeTrue();
+        }
+
+        [Fact]
+        public void RemovesEntityIndex()
+        {
+            var entityIndex = new PrimaryEntityIndex<TestEntity, string>(
+                "TestIndex",
+                _context.GetGroup(Matcher<TestEntity>.AllOf(1)),
+                (_, _) => string.Empty
+            );
+            _context.AddEntityIndex(entityIndex);
+            _context.RemoveEntityIndex(entityIndex.name);
+            _context.HasEntityIndex(entityIndex.name).Should().BeFalse();
+        }
+
+        [Fact]
+        public void ThrowsWhenRemovingEntityIndexThatDoesNotExist()
+        {
+            FluentActions.Invoking(() => _context.RemoveEntityIndex("unknown"))
+                .Should().Throw<ContextEntityIndexDoesNotExistException>();
+        }
+
+        [Fact]
+        public void ThrowsWhenGettingRemovedEntityIndex()
+        {
+            var entityIndex = new PrimaryEntityIndex<TestEntity, string>(
+                "TestIndex",
+                _context.GetGroup(Matcher<TestEntity>.AllOf(1)),
+                (_, _) => string.Empty
+            );
+            _context.AddEntityIndex(entityIndex);
+            _context.RemoveEntityIndex(entityIndex.name);
+            FluentActions.Invoking(() => _context.GetEntityIndex(entityIndex.name))
+                .Should().Throw<ContextEntityIndexDoesNotExistException>();
+        }
+
+        [Fact]
+        public void CanAddEntityIndexAfterRemoving()
+        {
+            var entityIndex = new PrimaryEntityIndex<TestEntity, string>(
+                "TestIndex",
+                _context.GetGroup(Matcher<TestEntity>.AllOf(1)),
+                (_, _) => string.Empty
+            );
+            _context.AddEntityIndex(entityIndex);
+            _context.RemoveEntityIndex(entityIndex.name);
+
+            var newEntityIndex = new PrimaryEntityIndex<TestEntity, string>(
+                "TestIndex",
+                _context.GetGroup(Matcher<TestEntity>.AllOf(1)),
+                (_, _) => string.Empty
+            );
+            _context.AddEntityIndex(newEntityIndex);
+            _context.GetEntityIndex(newEntityIndex.name).Should().BeSameAs(newEntityIndex);
+        }
+
+        [Fact]
         public void ResetsCreationIndex()
         {
             _context.CreateEntity();


### PR DESCRIPTION
Entitas-Flux v0.0.5

Added

- HasEntityIndex / RemoveEntityIndex on Context  
  New API methods on IContext and Context to check whether an entity index exists and to remove (with deactivation) an entity index by name. Includes full test coverage.

- Watched component introspection API  
  New WatchedEntityHasChangedGenerator that generates per-entity helper methods for watched components:
    - HasChanged(int componentId) — whether a watched component has changed
    - ComponentIsChangedFlag(int componentId) — whether a component ID is a "Changed" flag
    - GetOriginalComponentIdFromChangeFlag(int flagId) — resolves a flag back to its source component
    - IsWatchedComponent(int componentId) — whether a component is watched
    - GetChangedFlagIdOf(int componentId) — gets the flag ID for a watched component
    - GetChangeFlagTypeOf(int componentId) — gets the flag Type for a watched component

- Unity inspector triggers [Watched] change markers  
  Adding, removing, or editing a watched component through the Unity inspector now correctly adds the corresponding {Component}Changed marker component.


Fixed

- [DontGenerate] components still generated code  
  Components marked with [DontGenerate] were still producing generated output. Both reflection and Roslyn data providers now fully skip these components.

- EntityIndexGenerator generated for [DontGenerate] components  
  Entity index data providers (both reflection and Roslyn) now filter out [DontGenerate] components. Includes test fixture and tests.

- Primary index components with the same name but different contexts caused generation errors  
  EntityIndexGenerator now deduplicates index constant names via .Distinct().

- Watched component generated in one context only  
  When a [Watched] component belonged to multiple contexts, the generated {Component}Changed marker was only assigned to the first context. Both ComponentDataProvider implementations now merge context names across duplicates.

- Generated [Watched] component context order was non-deterministic  
  Context names on watched marker components are now sorted alphabetically for stable output.

- Generated cleanup systems order was non-deterministic  
  Both CleanupSystemsGenerator and WatchedCleanupSystemsGenerator now sort by context name and component name, producing deterministic output across builds.